### PR TITLE
Fix error of semantic release action

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [semantic_release]
 version_variable = setup.py:__version__
-branch = main
+branch = master
 upload_to_pypi = false


### PR DESCRIPTION
Correctly set the branch to which the new releases will be pushed to.

In this case we are not using main, which is the new standard for github, and instead we are using master.